### PR TITLE
Filter columns

### DIFF
--- a/core/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
@@ -183,12 +183,23 @@ class DefaultSourceSuite extends SHC with Logging {
     assert(s.count() == 1)
   }
 
-  test("IN filter stack overflow") {
+  test("IN filter rowkey stack overflow") {
     val df = withCatalog(catalog)
     val items = (0 to 2000).map{i => s"xaz$i"}
     val filterInItems = Seq("row001") ++: items
 
     val s = df.filter($"col0" isin(filterInItems:_*)).select("col0")
+    s.explain(true)
+    s.show()
+    assert(s.count() == 1)
+  }
+
+  test("IN filter column stack overflow") {
+    val df = withCatalog(catalog)
+    val items = (0 to 2000).map(_ + df.count() + 1)
+    val filterInItems = Seq(1) ++: items
+
+    val s = df.filter($"col4" isin(filterInItems:_*)).select("col0")
     s.explain(true)
     s.show()
     assert(s.count() == 1)

--- a/core/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
@@ -167,7 +167,6 @@ class DefaultSourceSuite extends SHC with Logging {
 
   test("IN and Not IN filter1") {
     val df = withCatalog(catalog)
-    df.show()
     val s = df.filter(($"col0" isin ("row005", "row001", "row002")) and !($"col0" isin ("row001", "row002")))
       .select("col0")
     s.explain(true)

--- a/core/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
@@ -153,8 +153,29 @@ class DefaultSourceSuite extends SHC with Logging {
     assert(c == 256)
   }
 
+  test("IN filter") {
+    val df = withCatalog(catalog)
+    df.show()
+    println(df.count())
+    val s = df.filter($"col4" isin (4, 5, 6)).select("col0")
+    s.explain(true)
+    s.show
+    assert(s.count() == 3)
+  }
+
+  test("IN filter rowkey") {
+    val df = withCatalog(catalog)
+    df.show()
+    println(df.count())
+    val s = df.filter($"col0" isin ("row005", "row001", "row002")).select("col0")
+    s.explain(true)
+    s.show
+    assert(s.count() == 3)
+  }
+
   test("IN and Not IN filter1") {
     val df = withCatalog(catalog)
+    df.show()
     val s = df.filter(($"col0" isin ("row005", "row001", "row002")) and !($"col0" isin ("row001", "row002")))
       .select("col0")
     s.explain(true)

--- a/core/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/DefaultSourceSuite.scala
@@ -153,23 +153,15 @@ class DefaultSourceSuite extends SHC with Logging {
     assert(c == 256)
   }
 
-  test("IN filter") {
+  test("IN filter for column") {
     val df = withCatalog(catalog)
-    df.show()
-    println(df.count())
     val s = df.filter($"col4" isin (4, 5, 6)).select("col0")
-    s.explain(true)
-    s.show
     assert(s.count() == 3)
   }
 
-  test("IN filter rowkey") {
+  test("IN filter for rowkey") {
     val df = withCatalog(catalog)
-    df.show()
-    println(df.count())
     val s = df.filter($"col0" isin ("row005", "row001", "row002")).select("col0")
-    s.explain(true)
-    s.show
     assert(s.count() == 3)
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

"IN" filter does not work properly for HBase columns. It multiplies number of rows without any filtering. The proposed change introduces a test that reveals the bug and fixes it.

## How was this patch tested?
Two unit tests have been added to DefaultSourceSuite:
* IN filter for column
* IN filter column stack overflow

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
